### PR TITLE
Regexmatch

### DIFF
--- a/CLR/regex/CLR/RegexFunctions.cs
+++ b/CLR/regex/CLR/RegexFunctions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+using System.Collections;
 using System.Data.SqlTypes;
 using System.Text.RegularExpressions;
 using Microsoft.SqlServer.Server;
@@ -26,14 +29,24 @@ public partial class UserDefinedFunctions
         return r1.Match(textString.TrimEnd(null)).Success;
     }
 
-    [SqlFunction]
-    public static SqlString RegexMatch(SqlString TextString, SqlString RegexPattern)
+    [SqlFunction(FillRowMethodName = "FillRegexMatches", TableDefinition = "value nvarchar(1000)")]
+    public static IEnumerable RegexMatch(SqlString TextString, SqlString RegexPattern)
     {
         var textString = (TextString.IsNull) ? "" : TextString.ToString();
         var regexPattern = (TextString.IsNull) ? "" : RegexPattern.ToString();
 
         Regex r1 = new Regex(regexPattern.TrimEnd(null));
-        var match = r1.Match(textString.TrimEnd(null)).Value;
-        return (match == "") ? (SqlString)null : match;
+
+        var matches = r1.Matches(textString.TrimEnd(null));
+        if (matches.Count > 0)
+        {
+            return matches.Cast<Match>().Select(m => m.Value.ToString());
+        }
+        return matches;
+    }
+
+    private static void FillRegexMatches(Object row, out SqlString str)
+    {
+        str = new SqlString((string)row);
     }
 }

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ SELECT regex.IsMatch('This is a test', '[\w]+') AS Result
 UNION ALL 
 SELECT regex.IsMatch('This is a test', '[\d]+')
 ```
-|      Result     |
-| --------------- |
-| 1  |
-| 0  |
+| Result |
+| ------ |
+| 1      |
+| 0      |
 
 ---
 
@@ -41,9 +41,9 @@ SELECT regex.IsMatch('This is a test', '[\d]+')
 SELECT value FROM dbo.RegexMatch('This is a test', '[\w]+')
 ```
 
-|      Result     |
-| --------------- |
+| value |
+| ----- |
 | This  |
-| is  |
-| a  |
+| is    |
+| a     |
 | test  |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # clr
 Safe assembly CLR database project with some basic text functions
 
------
+---
 
 ### CLR Scalar-Valued Functions for Regular Expressions
 
----
-
-regex.Replace (@TextString, @RegexPattern, @ReplaceString)
+`regex.Replace (@TextString, @RegexPattern, @ReplaceString)`
 
 ```sql
 SELECT regex.Replace('This     is   a     test', '\s+', ' ') as Result
@@ -19,7 +17,7 @@ SELECT regex.Replace('This     is   a     test', '\s+', ' ') as Result
 
 ---
 
-regex.IsMatch (@TextString, @RegexPattern)
+`regex.IsMatch (@TextString, @RegexPattern)`
 
 ```sql
 SELECT regex.IsMatch('This is a test', '[\w]+') AS Result
@@ -33,15 +31,19 @@ SELECT regex.IsMatch('This is a test', '[\d]+')
 
 ---
 
-regex.Match (@TextString, @RegexPattern)
+### CLR Tabled-Valued Functions for Regular Expressions
+
+---
+
+`regex.Match (@TextString, @RegexPattern)`
 
 ```sql
-SELECT regex.Match('This is a test', '[\w]+') AS Result
-UNION ALL 
-SELECT regex.Match('This is a test', '[\d]+')
+SELECT value FROM dbo.RegexMatch('This is a test', '[\w]+')
 ```
 
 |      Result     |
 | --------------- |
 | This  |
-| `NULL`  |
+| is  |
+| a  |
+| test  |


### PR DESCRIPTION
Converting `regex.Match` to a table-valued funtion (as a scalar, it only returned the first match it found)

closes #4 